### PR TITLE
カートの商品番号を選択した番号で表示できるようにする

### DIFF
--- a/lib/shopping_app.rb
+++ b/lib/shopping_app.rb
@@ -3,16 +3,16 @@ require_relative "shopping_app/item"
 require_relative "shopping_app/customer"
 
 seller = Seller.new("DICストア")
-10.times{ Item.new("CPU", 40830, seller) }
-10.times{ Item.new("メモリー", 13880, seller) }
-10.times{ Item.new("マザーボード", 28980, seller) }
-10.times{ Item.new("電源ユニット", 8980, seller) }
-10.times{ Item.new("PCケース", 8727, seller) }
-10.times{ Item.new("3.5インチHDD", 10980, seller) }
-10.times{ Item.new("2.5インチSSD", 13370, seller) }
-10.times{ Item.new("M.2 SSD", 12980, seller) }
-10.times{ Item.new("CPUクーラー", 13400, seller) }
-10.times{ Item.new("グラフィックボード", 23800, seller) }
+10.times{ Item.new(1, "CPU", 40830, seller) }
+10.times{ Item.new(2, "メモリー", 13880, seller) }
+10.times{ Item.new(3, "マザーボード", 28980, seller) }
+10.times{ Item.new(4, "電源ユニット", 8980, seller) }
+10.times{ Item.new(5, "PCケース", 8727, seller) }
+10.times{ Item.new(6, "3.5インチHDD", 10980, seller) }
+10.times{ Item.new(7, "2.5インチSSD", 13370, seller) }
+10.times{ Item.new(8, "M.2 SSD", 12980, seller) }
+10.times{ Item.new(9, "CPUクーラー", 13400, seller) }
+10.times{ Item.new(10, "グラフィックボード", 23800, seller) }
 
 puts "🤖 あなたの名前を教えてください"
 customer = Customer.new(gets.chomp)

--- a/lib/shopping_app/item.rb
+++ b/lib/shopping_app/item.rb
@@ -1,9 +1,10 @@
 class Item
-  attr_reader :name, :price
+  attr_reader :number, :name, :price
 
   @@instances = []
 
-  def initialize(name, price, owner=nil)
+  def initialize(number, name, price, owner=nil)
+    @number = number
     @name = name
     @price = price
     self.owner = owner
@@ -13,7 +14,7 @@ class Item
   end
 
   def label
-    { name: name, price: price }
+    { number: number, name: name, price: price }
   end
 
   def self.all

--- a/lib/shopping_app/item_manager.rb
+++ b/lib/shopping_app/item_manager.rb
@@ -9,17 +9,17 @@ module ItemManager
   end
 
   def pick_items(number, quantity) # numberと対応した自身の所有するItemインスタンスを指定されたquantitiy分返します。
-    items = stock.find{|stock| stock[:number] == number }&.dig(:items)
+    items = stock.find{|stock| stock[:label][:number] == number }&.dig(:items)
     return if items.nil? || items.size < quantity
     items.slice(0, quantity)
   end
 
   def items_list # 自身の所有するItemインスタンスの在庫状況を、["番号", "商品名", "金額", "数量"]という列でテーブル形式にして出力します。
-    kosi = Kosi::Table.new({header: %w{番号 商品名 金額 数量}}) # Gemgileに"kosi"のURLを記載
+    kosi = Kosi::Table.new({header: %w{商品番号 商品名 金額 数量}}) # Gemgileに"kosi"のURLを記載
     print kosi.render(
       stock.map do |stock|
         [
-          stock[:number],
+          stock[:label][:number],
           stock[:label][:name],
           stock[:label][:price],
           stock[:items].size
@@ -33,10 +33,10 @@ module ItemManager
   def stock # 自身の所有するItemインスタンスの在庫状況を返します。
     items
       .group_by{|item| item.label } # Item#labelで同じ値を返すItemインスタンスで分類します。
-      .map.with_index do |label_and_items, index|
+      .map do |label_and_items|
         {
-          number: index,
           label: {
+            number: label_and_items[0][:number],
             name: label_and_items[0][:name],
             price: label_and_items[0][:price],
           },


### PR DESCRIPTION
権限がないため、フォークしたリポジトリからプルリクエストを行いました

今まで、ショッピングプログラムの操作が、商品番号を選択してもカートにはインデックス番号が表示されるだけでしたので、違和感がありました。今回の修正で商品番号で対応できるように変更しました。
各商品には、あらかじめ１から順の商品番号を振っています。
